### PR TITLE
Feature/configure tmpdir

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -96,7 +96,7 @@ impl Config {
         if let Some(feed) = matches.value_of("feed") {
             config.feed = feed.parse().expect(&parse_failed("feed", feed));
         }
-        if let Some(tmp) = matches.value_of("tmp"){
+        if let Some(tmp) = matches.value_of("tmp") {
             config.tmp = Some(tmp.parse().expect(&parse_failed("tmp", tmp)));
         }
         config

--- a/src/config.rs
+++ b/src/config.rs
@@ -9,6 +9,7 @@ pub struct Config {
     pub buffer_size: usize,
     pub head: usize,
     pub feed: LineFeed,
+    pub tmp: Option<String>,
 }
 
 impl Config {
@@ -68,6 +69,13 @@ impl Config {
                     .help("Sets acceptable line feed as EOL (default: LF_CRLF).")
                     .takes_value(true),
             )
+            .arg(
+                Arg::with_name("tmp")
+                    .long("tmp")
+                    .value_name("PATH")
+                    .help("Sets temporary file directory. (default: Temporary directory set by the system.)")
+                    .takes_value(true),
+            )
             .get_matches();
         let parse_failed = |a: &str, s: &str| format!("Parse failed in command argument {}: {}", a, s);
         if let Some(log_level) = matches.value_of("log") {
@@ -88,6 +96,9 @@ impl Config {
         if let Some(feed) = matches.value_of("feed") {
             config.feed = feed.parse().expect(&parse_failed("feed", feed));
         }
+        if let Some(tmp) = matches.value_of("tmp"){
+            config.tmp = Some(tmp.parse().expect(&parse_failed("tmp", tmp)));
+        }
         config
     }
 
@@ -105,6 +116,7 @@ impl Default for Config {
             buffer_size: 4 * 1024 * 1024 * 1024,
             head: 0,
             feed: LineFeed::LF_CRLF,
+            tmp: Some(std::env::temp_dir().to_string_lossy().into_owned()),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,7 +116,7 @@ impl Default for Config {
             buffer_size: 4 * 1024 * 1024 * 1024,
             head: 0,
             feed: LineFeed::LF_CRLF,
-            tmp: Some(std::env::temp_dir().to_string_lossy().into_owned()),
+            tmp: None,
         }
     }
 }

--- a/src/shuffler/shuffle.rs
+++ b/src/shuffler/shuffle.rs
@@ -56,12 +56,12 @@ pub fn shuffle(conf: &Config) {
             }
         }
 
-        let file = if let Some(tmp) = &conf.tmp{
+        let file = if let Some(tmp) = &conf.tmp {
             NamedTempFile::new_in(tmp).unwrap()
-        }else{
+        } else {
             NamedTempFile::new().unwrap()
         };
-        info!("{:?}",file.path().to_str());
+        info!("{:?}", file.path().to_str());
         let shuf: Vec<usize> = fisher_yates_shuffle_n(rows.len());
         let mut tmp_writer = io::writer(file.path().to_str().unwrap());
         for i in shuf {

--- a/src/shuffler/shuffle.rs
+++ b/src/shuffler/shuffle.rs
@@ -30,7 +30,6 @@ pub fn shuffle(conf: &Config) {
         conf,
     );
 
-    info!("tmp dir: {:?}", conf.tmp);
     let mut tmp_files: Vec<TmpFile> = Vec::new();
     let mut total_rows: usize = 0;
     let mut reader_ind: usize = 0;
@@ -57,19 +56,22 @@ pub fn shuffle(conf: &Config) {
             }
         }
 
-        if let Some(tmp) = &conf.tmp {
-            let file = NamedTempFile::new_in(tmp).unwrap();
-            let shuf: Vec<usize> = fisher_yates_shuffle_n(rows.len());
-            let mut tmp_writer = io::writer(file.path().to_str().unwrap());
-            for i in shuf {
-                tmp_writer.write(format!("{}", rows[i]).as_bytes()).unwrap();
-            }
-            tmp_files.push(TmpFile {
-                remaining_row_count: rows.len(),
-                file: file,
-            });
-            total_rows += rows.len();
+        let file = if let Some(tmp) = &conf.tmp{
+            NamedTempFile::new_in(tmp).unwrap()
+        }else{
+            NamedTempFile::new().unwrap()
+        };
+        info!("{:?}",file.path().to_str());
+        let shuf: Vec<usize> = fisher_yates_shuffle_n(rows.len());
+        let mut tmp_writer = io::writer(file.path().to_str().unwrap());
+        for i in shuf {
+            tmp_writer.write(format!("{}", rows[i]).as_bytes()).unwrap();
         }
+        tmp_files.push(TmpFile {
+            remaining_row_count: rows.len(),
+            file: file,
+        });
+        total_rows += rows.len();
     }
     info!("finished writing to tmp files, count: {}", tmp_files.len());
     let mut tmp_file_readers: Vec<BufReader<File>> = Vec::with_capacity(tmp_files.len());


### PR DESCRIPTION
--tmpオプションで、rhuffleが使うtmpディレクトリの指定をできるように実装。
