### PR TITLE
Fix/unused io amount

### DIFF
--- a/src/shuffler/head.rs
+++ b/src/shuffler/head.rs
@@ -12,7 +12,7 @@ pub fn forward_head(reader: &mut dyn BufRead, writer: &mut dyn Write, conf: &Con
                 panic!("EOF detected while reading head {}-th line", i);
             }
             Ok(_) => {
-                writer.write_all(format!("{}", buf).as_bytes()).unwrap();
+                writer.write_all(buf.as_bytes()).unwrap();
             }
             Err(e) => {
                 panic!("An error occurred while reading line: {}", e);

--- a/src/shuffler/head.rs
+++ b/src/shuffler/head.rs
@@ -12,7 +12,7 @@ pub fn forward_head(reader: &mut dyn BufRead, writer: &mut dyn Write, conf: &Con
                 panic!("EOF detected while reading head {}-th line", i);
             }
             Ok(_) => {
-                writer.write(format!("{}", buf).as_bytes()).unwrap();
+                writer.write_all(format!("{}", buf).as_bytes()).unwrap();
             }
             Err(e) => {
                 panic!("An error occurred while reading line: {}", e);

--- a/src/shuffler/shuffle.rs
+++ b/src/shuffler/shuffle.rs
@@ -65,7 +65,7 @@ pub fn shuffle(conf: &Config) {
         let shuf: Vec<usize> = fisher_yates_shuffle_n(rows.len());
         let mut tmp_writer = io::writer(file.path().to_str().unwrap());
         for i in shuf {
-            tmp_writer.write(format!("{}", rows[i]).as_bytes()).unwrap();
+            tmp_writer.write_all(format!("{}", rows[i]).as_bytes()).unwrap();
         }
         tmp_files.push(TmpFile {
             remaining_row_count: rows.len(),
@@ -93,7 +93,7 @@ pub fn shuffle(conf: &Config) {
                 if size == 0 {
                     panic!("invalid EOF detected while reading tmp file!");
                 }
-                writer.write(format!("{}", buf).as_bytes()).unwrap();
+                writer.write_all(format!("{}", buf).as_bytes()).unwrap();
                 break;
             }
         }

--- a/src/shuffler/shuffle.rs
+++ b/src/shuffler/shuffle.rs
@@ -65,7 +65,7 @@ pub fn shuffle(conf: &Config) {
         let shuf: Vec<usize> = fisher_yates_shuffle_n(rows.len());
         let mut tmp_writer = io::writer(file.path().to_str().unwrap());
         for i in shuf {
-            tmp_writer.write_all(format!("{}", rows[i]).as_bytes()).unwrap();
+            tmp_writer.write_all(rows[i].as_bytes()).unwrap();
         }
         tmp_files.push(TmpFile {
             remaining_row_count: rows.len(),
@@ -93,7 +93,7 @@ pub fn shuffle(conf: &Config) {
                 if size == 0 {
                     panic!("invalid EOF detected while reading tmp file!");
                 }
-                writer.write_all(format!("{}", buf).as_bytes()).unwrap();
+                writer.write_all(buf.as_bytes()).unwrap();
                 break;
             }
         }


### PR DESCRIPTION
Since `Write::write` doesn't guarantee to write all the bytes given to it, `rhuffle` might truncate lines. This PR fixes this issue by replacing `write` with `write_all`. Also, unnecessary `format!` macro calls were removed in this PR.

FYI: This was caught by `cargo clippy`. Details are described [here](https://rust-lang.github.io/rust-clippy/master/#unused_io_amount).